### PR TITLE
Ensure metaclass consistency

### DIFF
--- a/stealth-mixin.lisp
+++ b/stealth-mixin.lisp
@@ -37,7 +37,8 @@ of 'victim-class'."
                                   (and (find-class ',victim-class nil)
                                        (closer-mop:class-direct-superclasses
                                         (find-class ',victim-class)))
-                                  :test #'class-equalp))
+                                  :test #'class-equalp)
+     :metaclass (class-of (find-class ',victim-class)))
 
     ;; Register it as a new mixin for the victim class
     (pushnew ',name (class-stealth-mixins ',victim-class))


### PR DESCRIPTION
This fixes a problem that occurs when trying to define a stealth mixin on a class that has a custom metaclass. Since metaclasses cannot be switched, we need to pass the class' class on as the metaclass argument when calling ensure-class.